### PR TITLE
refactor: minor builtins refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 
 # Output of the go coverage tool
 *.out
+
+/TODO*

--- a/builtins.go
+++ b/builtins.go
@@ -621,7 +621,7 @@ func builtinBytesFunc(args ...Object) (Object, error) {
 		return v, nil
 	}
 
-	out := Bytes{}
+	out := make(Bytes, 0, len(args))
 	for i, obj := range args {
 		switch v := obj.(type) {
 		case Int:
@@ -731,8 +731,8 @@ func builtinIsErrorFunc(args ...Object) (ret Object, err error) {
 	ret = False
 	switch len(args) {
 	case 1:
-		switch args[0].(type) {
-		case *Error, *RuntimeError:
+		// We have Error, BuiltinError and also user defined error types.
+		if _, ok := args[0].(error); ok {
 			ret = True
 		}
 	case 2:

--- a/bytecode.go
+++ b/bytecode.go
@@ -235,7 +235,7 @@ func (o *CompiledFunction) hash32() uint32 {
 	} else {
 		hash = hashData32(hash, []byte{0})
 	}
-	hash = hashData32(hash, []byte(o.Instructions))
+	hash = hashData32(hash, o.Instructions)
 	return hash
 }
 

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -282,7 +282,7 @@ types.
 **Examples**
 
 ```go
-v := cap([1, 2])   
+v := cap([1, 2])
 v = cap(bytes("abc"))
 ```
 

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -256,6 +256,38 @@ v = len(1)                    // v == 0
 
 ---
 
+### cap
+
+Returns the capacity of an array or bytes type. It always returns 0 for other
+types.
+
+**Syntax**
+
+> `cap(object)`
+
+**Parameters**
+
+- > `object`: valid types are following
+  - array
+  - bytes
+
+**Return Value**
+
+> int value
+
+**Runtime Errors**
+
+- > `WrongNumArgumentsError`
+
+**Examples**
+
+```go
+v := cap([1, 2])   
+v = cap(bytes("abc"))
+```
+
+---
+
 ### sort
 
 Returns sorted object in ascending order. Given object is modified if it is not

--- a/objects.go
+++ b/objects.go
@@ -603,14 +603,14 @@ func (o Bytes) BinaryOp(tok token.Token, right Object) (Object, error) {
 		case token.Add:
 			return append(o, v...), nil
 		case token.Less:
-			return Bool(bytes.Compare([]byte(o), []byte(v)) == -1), nil
+			return Bool(bytes.Compare(o, v) == -1), nil
 		case token.LessEq:
-			cmp := bytes.Compare([]byte(o), []byte(v))
+			cmp := bytes.Compare(o, v)
 			return Bool(cmp == 0 || cmp == -1), nil
 		case token.Greater:
-			return Bool(bytes.Compare([]byte(o), []byte(v)) == 1), nil
+			return Bool(bytes.Compare(o, v) == 1), nil
 		case token.GreaterEq:
-			cmp := bytes.Compare([]byte(o), []byte(v))
+			cmp := bytes.Compare(o, v)
 			return Bool(cmp == 0 || cmp == 1), nil
 		}
 	case String:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -754,7 +754,7 @@ func (p *Parser) parseGenDecl(
 	if p.token == token.LParen {
 		lparen = p.pos
 		p.next()
-		for iota := 0; p.token != token.RParen && p.token != token.EOF; iota++ {
+		for iota := 0; p.token != token.RParen && p.token != token.EOF; iota++ { //nolint:predeclared
 			list = append(list, fn(keyword, true, iota))
 		}
 		rparen = p.expect(token.RParen)

--- a/ugo.go
+++ b/ugo.go
@@ -364,7 +364,8 @@ func ToGoByteSlice(o Object) (v []byte, ok bool) {
 	case Bytes:
 		v, ok = o, true
 	case String:
-		v, ok = []byte(o), true
+		v, ok = make([]byte, len(o)), true
+		copy(v, o)
 	}
 	return
 }


### PR DESCRIPTION
- added overlooked cap builtin documentation
- isError builtin reports all error types as error
- pre-allocate byte slice in conversion functions
- removed unnecessary byte slice conversions
- fixed a linter warning