### PR TITLE
feat: add dollar as valid identifier char

### DIFF
--- a/compiler_test.go
+++ b/compiler_test.go
@@ -95,6 +95,16 @@ func TestCompiler_Compile(t *testing.T) {
 			withLocals(1),
 		),
 	))
+	expectCompile(t, `var $a`, bytecode(
+		Array{},
+		compFunc(concatInsts(
+			makeInst(OpNull),
+			makeInst(OpDefineLocal, 0),
+			makeInst(OpReturn, 0),
+		),
+			withLocals(1),
+		),
+	))
 	expectCompile(t, `var (a, b, c)`, bytecode(
 		Array{},
 		compFunc(concatInsts(

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -123,21 +123,16 @@ retValue, err := vm.Run(nil,  ugo.Int(34))
 /* ... */
 ```
 
-Valid identifiers start with `isLetter(char)` and followed by 
-`isLetter(char) || isDigit(char)`:
+Valid identifiers start with `isLetter(char)` and followed by `isLetter(char) || isDigit(char)`:
 
 ```go
 func isLetter(ch rune) bool {
-    return '$' == ch || 
-		'a' <= ch && ch <= 'z' || 
-		'A' <= ch && ch <= 'Z' || 
-		ch == '_' ||
+    return '$' == ch || 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' ||
         ch >= utf8.RuneSelf && unicode.IsLetter(ch)
 }
 
 func isDigit(ch rune) bool {
-    return '0' <= ch && ch <= '9' || 
-		ch >= utf8.RuneSelf && unicode.IsDigit(ch)
+    return '0' <= ch && ch <= '9' || ch >= utf8.RuneSelf && unicode.IsDigit(ch)
 }
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -129,7 +129,7 @@ or `isDigit(char)`:
 ```go
 func isLetter(ch rune) bool {
     return '$' == ch || 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || 
-		ch == '_' || ch >= utf8.RuneSelf && unicode.IsLetter(ch)
+        ch == '_' || ch >= utf8.RuneSelf && unicode.IsLetter(ch)
 }
 
 func isDigit(ch rune) bool {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -123,6 +123,30 @@ retValue, err := vm.Run(nil,  ugo.Int(34))
 /* ... */
 ```
 
+Valid identifiers start with `isLetter(char)` and followed by 
+`isLetter(char) || isDigit(char)`:
+
+```go
+func isLetter(ch rune) bool {
+    return '$' == ch || 
+		'a' <= ch && ch <= 'z' || 
+		'A' <= ch && ch <= 'Z' || 
+		ch == '_' ||
+        ch >= utf8.RuneSelf && unicode.IsLetter(ch)
+}
+
+func isDigit(ch rune) bool {
+    return '0' <= ch && ch <= '9' || 
+		ch >= utf8.RuneSelf && unicode.IsDigit(ch)
+}
+```
+
+Valid identifier examples:
+
+```go
+var (_, _a, $_a, a, A, $b, $, a1, $1, $b1, $$, ŝ, $ŝ)
+```
+
 Global variables can be provided to VM which are declared with
 [`global`](#global) keyword. Globals are accessible to source modules as well.
 Map like objects should be used to get/set global variables as below.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -123,12 +123,13 @@ retValue, err := vm.Run(nil,  ugo.Int(34))
 /* ... */
 ```
 
-Valid identifiers start with `isLetter(char)` and followed by `isLetter(char) || isDigit(char)`:
+Valid identifiers start with `isLetter(char)` and followed by `isLetter(char)`
+or `isDigit(char)`:
 
 ```go
 func isLetter(ch rune) bool {
-    return '$' == ch || 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' ||
-        ch >= utf8.RuneSelf && unicode.IsLetter(ch)
+    return '$' == ch || 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || 
+		ch == '_' || ch >= utf8.RuneSelf && unicode.IsLetter(ch)
 }
 
 func isDigit(ch rune) bool {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -232,6 +232,9 @@ b)`, func(p pfn) []Stmt {
 	expectParseString(t, "global (x,\ny)", "global (x, y)")
 	expectParseString(t, "global (x\ny)", "global (x, y)")
 
+	expectParseString(t, `var (_, _a, $_a, a, A, $b, $, a1, $1, $b1, $$, ŝ, $ŝ)`,
+		`var (_, _a, $_a, a, A, $b, $, a1, $1, $b1, $$, ŝ, $ŝ)`)
+
 	expectParse(t, `var a`, func(p pfn) []Stmt {
 		return stmts(
 			declStmt(

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -298,7 +298,7 @@ func (s *Scanner) scanComment() string {
 	var numCR int
 
 	if s.ch == '/' {
-		//-style comment
+		// -style comment
 		// (the final '\n' is not considered part of the comment)
 		s.next()
 		for s.ch != '\n' && s.ch >= 0 {
@@ -356,7 +356,7 @@ func (s *Scanner) findLineEnd() bool {
 	// read ahead until a newline, EOF, or non-comment tok is found
 	for s.ch == '/' || s.ch == '*' {
 		if s.ch == '/' {
-			//-style comment always contains a newline
+			// -style comment always contains a newline
 			return true
 		}
 		/*-style comment: look for newline */
@@ -689,13 +689,12 @@ func (s *Scanner) switch4(
 }
 
 func isLetter(ch rune) bool {
-	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' ||
+	return '$' == ch || 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' ||
 		ch >= utf8.RuneSelf && unicode.IsLetter(ch)
 }
 
 func isDigit(ch rune) bool {
-	return '0' <= ch && ch <= '9' ||
-		ch >= utf8.RuneSelf && unicode.IsDigit(ch)
+	return '0' <= ch && ch <= '9' || ch >= utf8.RuneSelf && unicode.IsDigit(ch)
 }
 
 func digitVal(ch rune) int {

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -38,6 +38,11 @@ func TestScanner_Scan(t *testing.T) {
 		{token.Ident, "bar９８７６"},
 		{token.Ident, "ŝ"},
 		{token.Ident, "ŝfoo"},
+		{token.Ident, "$"},
+		{token.Ident, "$$$"},
+		{token.Ident, "_"},
+		{token.Ident, "__"},
+		{token.Ident, "$_"},
 		{token.Int, "0"},
 		{token.Int, "1"},
 		{token.Int, "123456789012345678890"},
@@ -170,7 +175,7 @@ func TestScanner_Scan(t *testing.T) {
 			expectedLiteral = string(parser.StripCR([]byte(tc.literal),
 				tc.literal[1] == '*'))
 
-			//-style comment literal doesn't contain newline
+			// -style comment literal doesn't contain newline
 			if expectedLiteral[1] == '/' {
 				expectedLiteral = expectedLiteral[:len(expectedLiteral)-1]
 			}


### PR DESCRIPTION
This PR will allow the use of the dollar in identifiers, such as JavaScript. 

My intention is to create a template language with UGO, and define the dollar prefixed variables will make it more intuitive.